### PR TITLE
AI Generated pull-request: fix(serial): close WebSerial port on page unload to prevent replug

### DIFF
--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -325,6 +325,60 @@ class WebSerial extends EventTarget {
         }
     }
 
+    forceClose() {
+        // Best-effort teardown for page-unload (pagehide / beforeunload).
+        // Instance refs are nulled immediately so the rest of the class sees a
+        // disconnected state; the actual async teardown runs in a Promise chain
+        // that Chrome typically drains before destroying the JS context.
+        if (!this.port && !this.reader && !this.writer) {
+            return;
+        }
+
+        this.connected = false;
+        this.transmitting = false;
+        this.reading = false;
+
+        this.removeEventListener("receive", this.handleReceiveBytes);
+
+        const reader = this.reader;
+        const writer = this.writer;
+        const port = this.port;
+        this.reader = null;
+        this.writer = null;
+        this.port = null;
+
+        if (port) port.removeEventListener("disconnect", this.handleDisconnect);
+
+        // Mirrors the disconnect() sequence but without awaiting at call-site.
+        (async () => {
+            // 1. Cancel reader — resolves the pending read in streamAsyncIterable,
+            //    whose finally block will call releaseLock() on the readable side.
+            if (reader) {
+                try {
+                    await reader.cancel();
+                } catch (_) {}
+            }
+
+            if (writer) {
+                try {
+                    writer.releaseLock();
+                } catch (_) {}
+            }
+
+            // Close port — Chrome allows this after reader.cancel() even if the
+            // reader lock is still technically held (streamAsyncIterable cleans up).
+            if (port) {
+                try {
+                    await port.close();
+                } catch (_) {}
+            }
+        })();
+
+        this.closeRequested = false;
+        this.connectionInfo = null;
+        this.connectionId = false;
+    }
+
     checkIsNeedBatchWrite() {
         const isMac = GUI.operating_system === "MacOS";
         return isMac && vendorIdNames[this.connectionInfo.usbVendorId] === "AT32";

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -208,6 +208,14 @@ class Serial extends EventTarget {
         return result;
     }
 
+    forceClose() {
+        try {
+            this._protocol?.forceClose?.();
+        } catch (error) {
+            console.error(`${this.logHead} Error during force close:`, error);
+        }
+    }
+
     /**
      * Get the currently connected port
      */

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -91,6 +91,15 @@ export function initializeSerialBackend() {
 
     PortHandler.initialize();
     PortUsage.initialize();
+
+    // On page unload (refresh / tab close) close the serial port so the FC
+    // gets a clean disconnect and reconnection works without a physical replug.
+    window.addEventListener("pagehide", () => {
+        if (isConnected && !GUI.connect_lock) {
+            console.log(`${logHead} Page unloading while connected — force-closing serial port`);
+            serial.forceClose();
+        }
+    });
 }
 
 async function sendConfigTracking() {


### PR DESCRIPTION
## Summary

- Adds a `pagehide` listener in `initializeSerialBackend()` that calls `serial.forceClose()` when the page is refreshed or the tab is closed while connected
- Adds `forceClose()` to `WebSerial` — mirrors `disconnect()`'s cleanup sequence (cancel reader, release writer lock, close port) as a fire-and-forget async IIFE since `pagehide` handlers cannot `await`
- Adds `forceClose()` delegation on the `Serial` wrapper class with error handling

resolves betaflight/betaflight-configurator#5109

## Test plan

- [ ] Connect to FC via USB (non-CLI tab)
- [ ] Press F5 or Ctrl+R to refresh
- [ ] Verify reconnect works without unplugging USB
- [ ] Verify normal disconnect button still works
- [ ] Verify tab close and reopen reconnects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)